### PR TITLE
Add validateProjectCredentials method for project credential validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 1.5.0 - 2025-11-24
+### Added
+- Added `validateProjectCredentials()` method for validating project credentials without authentication
+- Added `ProjectCredentials` entity class for credentials validation
+
 ## 1.4.0 - 2025-11-24
 ### Fixed
 - Fixed working with files

--- a/README.md
+++ b/README.md
@@ -54,7 +54,35 @@ $result = $merchantClient->getDefaultPackageSizes($filter);
 ```
 ---
 
-    
+
+Validate project credentials
+
+
+```php
+use Paysera\DeliveryApi\MerchantClient\Entity\ProjectCredentials;
+use RuntimeException;
+
+$credentials = new ProjectCredentials();
+
+$credentials->setProjectId($projectId);
+$credentials->setPassword($password);
+
+try {
+    $isValid = $merchantClient->validateProjectCredentials($credentials);
+
+    if ($isValid) {
+        // Credentials are valid
+    } else {
+        // Invalid credentials
+    }
+} catch (RuntimeException $e) {
+    // Handle rate limit or other errors
+    echo $e->getMessage();
+}
+```
+---
+
+
 Get shipment method by id
 
 

--- a/src/Entity/ProjectCredentials.php
+++ b/src/Entity/ProjectCredentials.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Paysera\DeliveryApi\MerchantClient\Entity;
+
+use Paysera\Component\RestClientCommon\Entity\Entity;
+
+class ProjectCredentials extends Entity
+{
+    public function __construct(array $data = [])
+    {
+        parent::__construct($data);
+    }
+
+    /**
+     * @return string
+     */
+    public function getProjectId()
+    {
+        return $this->get('project_id');
+    }
+
+    /**
+     * @param string $projectId
+     * @return $this
+     */
+    public function setProjectId($projectId)
+    {
+        $this->set('project_id', $projectId);
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPassword()
+    {
+        return $this->get('password');
+    }
+
+    /**
+     * @param string $password
+     * @return $this
+     */
+    public function setPassword($password)
+    {
+        $this->set('password', $password);
+        return $this;
+    }
+}


### PR DESCRIPTION
  ## Summary
  Added a new public method `validateProjectCredentials()` to the `MerchantClient` class that allows validating project credentials against the API without requiring prior authentication.

  ## Changes Made

  ### Modified Files
  - **src/MerchantClient.php**
    - Added `validateProjectCredentials()` method (lines 969-1017)
    - Method uses POST `/projects/validate-credentials` endpoint
    - Returns `bool` - `true` if credentials are valid, `false` if invalid
    - Throws `RuntimeException` for rate limits or unexpected errors
    - Added imports: `RuntimeException`, `ProjectCredentials`
    - Removed unused import `GuzzleHttp\Exception\RequestException`

  ### Added Files
  - **src/Entity/ProjectCredentials.php**
    - New entity class for passing project credentials
    - Contains `project_id` and `password` fields
    - Extends base `Entity` class with getters/setters

  ## Features
  - **Unauthenticated endpoint**: This endpoint does not require API authentication
  - **Simple validation**: Returns boolean result for easy integration
  - **Rate limit handling**: Properly handles and reports rate limit errors (429)
  - **Error handling**: Throws exceptions for unexpected scenarios with descriptive messages

  ## Usage Example
  ```php
  use Paysera\DeliveryApi\MerchantClient\Entity\ProjectCredentials;

  $credentials = new ProjectCredentials();
  $credentials->setProjectId('12345');
  $credentials->setPassword('secret-password');

  try {
      $isValid = $merchantClient->validateProjectCredentials($credentials);

      if ($isValid) {
          // Credentials are valid (204 response)
      } else {
          // Invalid credentials (401 response)
      }
  } catch (RuntimeException $e) {
      // Handle rate limit (429) or other errors
  }

  Implementation Details

  The method:
  1. Uses existing ApiClient infrastructure with http_errors: false option
  2. Creates POST request to projects/validate-credentials endpoint
  3. Sends credentials as JSON in request body
  4. Returns true for HTTP 204 (valid credentials)
  5. Returns false for HTTP 401 (invalid credentials)
  6. Throws RuntimeException for HTTP 429 (rate limit) or other errors

  Testing Checklist

  - Returns true when valid credentials are provided (204 response)
  - Returns false when invalid credentials are provided (401 response)
  - Throws RuntimeException with appropriate message for rate limit errors (429)
  - Throws RuntimeException for unexpected status codes
  - Handles network errors gracefully
